### PR TITLE
_detectedReferenceAnchorsの値がnullになるケースに対応

### DIFF
--- a/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/ARTrackedImageEventManager.cs
+++ b/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/ARTrackedImageEventManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.XR.ARSubsystems;
 using UnityEngine.XR.ARFoundation;
@@ -12,15 +13,22 @@ namespace Hado.ARFoundation
     {
         private readonly Subject<ARTrackedImage> _trackImagesChangedSubject = new Subject<ARTrackedImage>();
 
-        public IObservable<ARTrackedImage> OnTrackedImagesChangedObservable => _trackImagesChangedSubject.AsObservable();
+        public IObservable<ARTrackedImage> TrackedImagesChangedObservable => _trackImagesChangedSubject.AsObservable();
 
         private ARTrackedImageManager _mTrackedImageManager;
 
-        private readonly Dictionary<string, GameObject> _detectedReferenceAnchors = new Dictionary<string, GameObject>();
+        private readonly Dictionary<string, GameObject>
+            _detectedReferenceAnchors = new Dictionary<string, GameObject>();
 
         public GameObject GetReferenceAnchor(string imageName)
         {
-            return _detectedReferenceAnchors.ContainsKey(imageName) ? _detectedReferenceAnchors[imageName] : null;
+            var ret = _detectedReferenceAnchors.GetValueOrDefault(imageName);
+
+            // 初回マーカー認識後にNative側で"UnityARKit: Updating ARSession configuration"があると、keyはあるのにAnchorがnullという状態が発生する
+            // その場合は一度クリアして再度Anchorを設定する
+            if (ret == null) Clear();
+
+            return ret;
         }
 
         public void Clear()
@@ -51,7 +59,7 @@ namespace Hado.ARFoundation
             {
                 // 初回だけの処理はここに
                 Debug.Log($"OnTrackedImagesChanged: add: {trackedImage.trackingState}");
-                if(!_detectedReferenceAnchors.ContainsKey(trackedImage.referenceImage.name))
+                if (!_detectedReferenceAnchors.ContainsKey(trackedImage.referenceImage.name))
                     InitAnchorTransform(trackedImage);
                 _trackImagesChangedSubject.OnNext(trackedImage);
             }
@@ -59,12 +67,12 @@ namespace Hado.ARFoundation
             foreach (var trackedImage in eventArgs.updated)
             {
                 if (trackedImage.trackingState != TrackingState.Tracking) return;
-                
+
                 //TODO: 稀に初回detectなのにupdateで渡されることがある
-                if(!_detectedReferenceAnchors.ContainsKey(trackedImage.referenceImage.name))
+                if (!_detectedReferenceAnchors.ContainsKey(trackedImage.referenceImage.name))
                     InitAnchorTransform(trackedImage);
-                    
-                
+
+
                 Debug.Log($"OnTrackedImagesChanged: updated: {trackedImage.trackingState}");
                 _trackImagesChangedSubject.OnNext(trackedImage);
             }
@@ -72,7 +80,7 @@ namespace Hado.ARFoundation
 
         private void InitAnchorTransform(ARTrackedImage trackedImage)
         {
-            Debug.Log("InitAnchorTransform");
+            Debug.Log($"InitAnchorTransform: {trackedImage.referenceImage.name}");
             var markerName = trackedImage.referenceImage.name;
             var anchor = trackedImage.GetComponentInChildren<Anchor>();
             anchor.Name = markerName;

--- a/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/WorldAnchorManager.cs
+++ b/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/WorldAnchorManager.cs
@@ -31,6 +31,8 @@ namespace Hado.ARFoundation
 
         public ReactiveProperty<MovingStatus> IsMoving { get; } = new ReactiveProperty<MovingStatus>(MovingStatus.None);
 
+        private CancellationTokenSource _cancellationTokenSource;
+
         private void Awake()
         {
             PositionManager.Instance.WorldAnchor = gameObject;
@@ -40,13 +42,14 @@ namespace Hado.ARFoundation
         {
             var moveStartTransform = gameObject.transform;
             
-            ARSessionManager.Instance.arTrackedImageEventManager.OnTrackedImagesChangedObservable
+            ARSessionManager.Instance.arTrackedImageEventManager.TrackedImagesChangedObservable
                 .Where(_ => IsMoving.Value == MovingStatus.None) // 補正中は流さない
                 .Do(t => PositionManager.Instance.LastDetectedAnchorName = t.referenceImage.name)
                 .Do(t => Debug.Log($"{t.referenceImage.name} detected"))
-                .Select(t =>
-                    ARSessionManager.Instance.arTrackedImageEventManager.GetReferenceAnchor(t.referenceImage.name)
-                        .transform.position)
+                .Select(t => ARSessionManager.Instance.arTrackedImageEventManager.GetReferenceAnchor(t.referenceImage
+                    .name))
+                .Where(x => x != null) // なぜnullがあるかはARTrackedImageEventManagerを参照
+                .Select(x => x.transform.position)
                 .Where(_ => ARSession.state >= ARSessionState.SessionInitializing)
                 .Buffer(NoiseCheckSampleCount + 1)
                 .Subscribe(positions =>
@@ -64,9 +67,11 @@ namespace Hado.ARFoundation
                     var moveEndRotation =
                         ARSessionManager.Instance.arTrackedImageEventManager.GetReferenceAnchor(PositionManager.Instance
                             .LastDetectedAnchorName).transform.rotation;
-                    
-                    
-                    MoveToX(moveStartTransform.position, moveStartTransform.rotation, positions[2], moveEndRotation);
+
+                    _cancellationTokenSource?.Cancel();
+                    _cancellationTokenSource?.Dispose();
+                    _cancellationTokenSource = new CancellationTokenSource();
+                    MoveToX(moveStartTransform.position, moveStartTransform.rotation, positions[2], moveEndRotation, _cancellationTokenSource.Token).Forget();
                     
                 }).AddTo(this);
         }
@@ -84,36 +89,23 @@ namespace Hado.ARFoundation
             return _noiseCheckSamples.Any(x => x > MovingNoiseThreshold);
         }
 
-        public IDisposable RegisterIntervalTracking(CancellationTokenSource cancellationTokenSource,
+        public IDisposable RegisterIntervalTracking(CancellationToken cancellationToken,
             int imageTrackingIntervalMils = 3000)
         {
             Debug.Log("RegisterIntervalTracking");
-            return ARSessionManager.Instance.arTrackedImageEventManager.OnTrackedImagesChangedObservable
+            return ARSessionManager.Instance.arTrackedImageEventManager.TrackedImagesChangedObservable
                 .Where(_ => IsMoving.Value == MovingStatus.Moving) // 補正が始まったら発火
-                .Subscribe(async _ =>
+                .Subscribe(_ => UniTask.Void(async () =>
                     {
                         ARSessionManager.Instance.EnabledImageTracking = false;
-
-                        await WaitForMoveEnd();
-
-                        await UniTask.Delay(TimeSpan.FromMilliseconds(imageTrackingIntervalMils));
-
-                        if (cancellationTokenSource.Token.IsCancellationRequested) return;
-
+                        await UniTask.WaitWhile(() => IsMoving.Value == MovingStatus.Moving, cancellationToken: cancellationToken);
+                        await UniTask.Delay(TimeSpan.FromMilliseconds(imageTrackingIntervalMils), cancellationToken: cancellationToken);
                         ARSessionManager.Instance.EnabledImageTracking = true;
                     }
-                );
+                ));
         }
 
-        private async UniTask WaitForMoveEnd()
-        {
-            while (IsMoving.Value == MovingStatus.Moving)
-            {
-                await UniTask.NextFrame();
-            }
-        }
-        
-        private async UniTask MoveToX(Vector3 startPos, Quaternion startRot, Vector3 endPos, Quaternion endRot)
+        private async UniTask MoveToX(Vector3 startPos, Quaternion startRot, Vector3 endPos, Quaternion endRot, CancellationToken cancellationToken)
         {
             IsMoving.Value = MovingStatus.Moving;
 
@@ -134,7 +126,7 @@ namespace Hado.ARFoundation
                 gameObject.transform.position = Vector3.Lerp(startPos, endPos, lerpPoint);
                 gameObject.transform.rotation = Quaternion.Lerp(startRot, endRot, lerpPoint);
 
-                await UniTask.WaitForEndOfFrame();
+                await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
マーカー認識後にNative側で"UnityARKit: Updating ARSession configuration"があると、keyはあるのにAnchorがnullという状態が発生する
その場合は一度クリアして再度Anchorを設定する