### PR TITLE
AnchorのOffsetが多重処理になってるのを修正

### DIFF
--- a/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/ARTrackedImageEventManager.cs
+++ b/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/ARTrackedImageEventManager.cs
@@ -84,8 +84,10 @@ namespace Hado.ARFoundation
             Debug.Log($"Anchor Offset: {offset.Position}, {offset.Rotation.eulerAngles}");
 
             var t = anchor.gameObject.transform;
+            t.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
             t.localPosition = m.MultiplyPoint3x4(t.localPosition);
             t.rotation *= Quaternion.Inverse(offset.Rotation);
+            Debug.Log($"Set Anchor Position: {t.localPosition}, {t.localRotation.eulerAngles}");;
             return anchor;
         }
     }


### PR DESCRIPTION
https://github.com/meleap/ARFoundationTrackingPlugin/blob/develop/Assets/Plugins/ARFoundationTrackingPlugin/Scripts/Hado/ARFoundation/ARTrackedImageStabler.cs#L84
StablerのClearが発生した時に再度Anchorの初期化処理が走るが、使われるAnchorGameObjectは前回のOffsetを保持していたため二重処理になっていた。
処理前にOffsetを初期化する。


